### PR TITLE
Update requirements.txt to depend on `qiskit` instead of `qiskit-terra`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-qiskit-terra>=0.23
+qiskit>=0.40
 rustworkx>=0.12.1


### PR DESCRIPTION
in two week, `qiskit` metapackage wont exist as a metapackage. It is safer to depend directoy on `qiskit` instead of the content of the metapackage (ie `qiskit-terra`)